### PR TITLE
[Breaking Change] Fix `includeYear` to honor `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- **Breaking change**: `{includeYear: false}` now hides the year in every case.
+
+  Previously, passing `false` was not a reliable way to hide the year: it behaved the same as `true` for the current year, and was silently ignored for past or future years. The option is now a symmetric counterpart to `{includeYear: true}`.
+
+  The default behavior when the option is not present is unchanged: hide the year when it matches the current year, and show it otherwise.
+
 ## 3.1.0
 
 - Ship TypeScript type definitions with the package

--- a/README.md
+++ b/README.md
@@ -81,16 +81,24 @@ moonWalk.getAPDate();
 
 Available options:
 
-- `includeYear`: Always include the year, even if it matches the current one:
+- `includeYear`: Force the year to be included or excluded.
+
+  The default hides the year when it matches the current year, and shows it otherwise. Pass `true` to force the year on, or `false` to force it off — both override the default regardless of the date.
 
 ```js
-// Today is August 28, 2014...
+// Today is August 28, 2014
 
 Dateline().getAPDate();
 // -> 'Aug. 28'
 
+Dateline(new Date(2012, 7, 28)).getAPDate();
+// -> 'Aug. 28, 2012'
+
 Dateline().getAPDate({includeYear: true});
 // -> 'Aug. 28, 2014'
+
+Dateline(new Date(2012, 7, 28)).getAPDate({includeYear: false});
+// -> 'Aug. 28'
 ```
 
 - `useDayNameForLastWeek`: Use the day of the week for dates in the last seven days:

--- a/dateline.js
+++ b/dateline.js
@@ -110,7 +110,10 @@ function showMinutes(minutes, options) {
 // # Date Helpers
 
 function showYear(year, options) {
-  return year === new Date().getFullYear() && options.includeYear == null;
+  if (options.includeYear == null) {
+    return year === new Date().getFullYear();
+  }
+  return !options.includeYear;
 }
 
 function getDayOfWeek(dateObj) {

--- a/test/date_test.js
+++ b/test/date_test.js
@@ -58,7 +58,7 @@ describe("#getAPDate", function () {
       });
     });
 
-    describe('always show the year when "includeYear" option is passed', function () {
+    describe('always show the year when "includeYear" is true', function () {
       it("shows year for past years", function () {
         let actual = Dateline(new Date(2012, 11, 31)).getAPDate({
           includeYear: true,
@@ -78,6 +78,29 @@ describe("#getAPDate", function () {
           includeYear: true,
         });
         expect(actual).toBe("Dec. 31, 2014");
+      });
+    });
+
+    describe('always hide the year when "includeYear" is false', function () {
+      it("hides year for past years", function () {
+        let actual = Dateline(new Date(2012, 11, 31)).getAPDate({
+          includeYear: false,
+        });
+        expect(actual).toBe("Dec. 31");
+      });
+
+      it("hides year for the current year", function () {
+        let actual = Dateline(new Date(2013, 11, 31)).getAPDate({
+          includeYear: false,
+        });
+        expect(actual).toBe("Dec. 31");
+      });
+
+      it("hides year for future years", function () {
+        let actual = Dateline(new Date(2014, 11, 31)).getAPDate({
+          includeYear: false,
+        });
+        expect(actual).toBe("Dec. 31");
       });
     });
   });


### PR DESCRIPTION
## tl;dr

`{includeYear: false}` now reliably hides the year. It previously behaved the same as `{includeYear: true}` for the current year and was silently ignored for past/future years.

## What changed?

- `showYear` now checks `options.includeYear` for truthiness instead of gating on `== null`. Missing still hides the current year by default; truthy always shows; falsy always hides.
- Added tests in `test/date_test.js` covering `{includeYear: false}` across past, current, and future years.
- Updated the `includeYear` section of `README.md` to describe the full tri-state and include an example of `false` forcing the year off.
- Added a breaking-change entry to `CHANGELOG.md`.

## Why?

The option was gated by an existence check (`options.includeYear == null`) rather than a truthiness check, so `false` couldn't express "hide the year." Callers who wanted year-free rendering had no way to opt in via the option — they had to rely on the current-year default, which only worked on the current calendar year.

This is a breaking change: any caller currently passing `includeYear: false` against the current year will see the year disappear. That previous behavior was a bug rather than a feature, but it's called out in the changelog so upgraders can audit.