### PR TITLE
Add `useDayNameWithinWeek` option to `getAPDate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Added `useDayNameWithinWeek` option to `getAPDate`. Renders the weekday name for dates within a week of today in either direction, matching AP style.
+
 - **Breaking change**: `{includeYear: false}` now hides the year in every case.
 
   Previously, passing `false` was not a reliable way to hide the year: it behaved the same as `true` for the current year, and was silently ignored for past or future years. The option is now a symmetric counterpart to `{includeYear: true}`.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ Dateline(new Date(2012, 7, 28)).getAPDate({includeYear: false});
 // -> 'Aug. 28'
 ```
 
+- `useDayNameWithinWeek`: Use the day of the week for dates within seven days of today, in either direction.
+
+  Per AP style, weekday names stand in for the date within a week of the current date. The fallback kicks in at exactly seven days out in either direction — those dates render normally.
+
+```js
+// Today is Wednesday, January 2, 2013
+
+Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Tuesday'
+
+Dateline(new Date(2013, 0, 2)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Wednesday'
+
+Dateline(new Date(2013, 0, 3)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Thursday'
+
+Dateline(new Date(2013, 0, 9)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Jan. 9'
+```
+
 - `useDayNameForLastWeek`: Use the day of the week for dates in the last seven days:
 
 ```js

--- a/dateline.js
+++ b/dateline.js
@@ -121,10 +121,18 @@ function getDayOfWeek(dateObj) {
 }
 
 function useDayName(dateObj, options) {
+  if (options.useDayNameWithinWeek != null) {
+    return options.useDayNameWithinWeek && withinAWeek(dateObj);
+  }
   return options.useDayNameForLastWeek != null && withinSevenDays(dateObj);
 }
 
 function withinSevenDays(dateObj) {
   let diffInDays = (dateObj - new Date()) / ONE_DAY_IN_MS;
   return -7 < diffInDays && diffInDays < 0;
+}
+
+function withinAWeek(dateObj) {
+  let diffInDays = (dateObj - new Date()) / ONE_DAY_IN_MS;
+  return -7 < diffInDays && diffInDays < 7;
 }

--- a/test/date_test.js
+++ b/test/date_test.js
@@ -195,5 +195,81 @@ describe("#getAPDate", function () {
         });
       });
     });
+
+    describe("dates within a week in either direction", function () {
+      describe('when "useDayNameWithinWeek" is true', function () {
+        it("shows the day of the week for one day ago", function () {
+          let actual = Dateline(new Date(2013, 0, 1)).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Tuesday");
+        });
+
+        it("shows the day of the week for today", function () {
+          let actual = Dateline(new Date(2013, 0, 2)).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Wednesday");
+        });
+
+        it("shows the day of the week for one day ahead", function () {
+          let actual = Dateline(new Date(2013, 0, 3)).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Thursday");
+        });
+
+        it("falls back to the date exactly seven days ago", function () {
+          let actual = Dateline(new Date(2012, 11, 26)).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Dec. 26, 2012");
+        });
+
+        it("falls back to the date exactly seven days ahead", function () {
+          let actual = Dateline(new Date(2013, 0, 9)).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Jan. 9");
+        });
+      });
+
+      describe('when "useDayNameWithinWeek" is false', function () {
+        it("renders the date one day ago", function () {
+          let actual = Dateline(new Date(2013, 0, 1)).getAPDate({
+            useDayNameWithinWeek: false,
+          });
+          expect(actual).toBe("Jan. 1");
+        });
+
+        it("renders the date today", function () {
+          let actual = Dateline(new Date(2013, 0, 2)).getAPDate({
+            useDayNameWithinWeek: false,
+          });
+          expect(actual).toBe("Jan. 2");
+        });
+
+        it("renders the date one day ahead", function () {
+          let actual = Dateline(new Date(2013, 0, 3)).getAPDate({
+            useDayNameWithinWeek: false,
+          });
+          expect(actual).toBe("Jan. 3");
+        });
+
+        it("renders the date exactly seven days ago", function () {
+          let actual = Dateline(new Date(2012, 11, 26)).getAPDate({
+            useDayNameWithinWeek: false,
+          });
+          expect(actual).toBe("Dec. 26, 2012");
+        });
+
+        it("renders the date exactly seven days ahead", function () {
+          let actual = Dateline(new Date(2013, 0, 9)).getAPDate({
+            useDayNameWithinWeek: false,
+          });
+          expect(actual).toBe("Jan. 9");
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## tl;dr

Adds a new `useDayNameWithinWeek` option to `getAPDate` that renders the weekday name for dates within a week of today in either direction.

## What changed?

- New `useDayNameWithinWeek` option on `getAPDate`. When truthy, dates with a diff in `(-7, 7)` days — today inclusive, both seven-day boundaries excluded — render as the weekday name; outside the window, the date falls back to the default month+day rendering.
- New tests covering `{true, false}` at one day ago, today, one day ahead, exactly seven days ago, and exactly seven days ahead.

## Why?

The existing `useDayNameForLastWeek` is past-facing only, which doesn't match AP style: *"Use Monday, Tuesday, etc., for days of the week within seven days before or after the current date."* The new option widens the window to match the spec and ships under a name that no longer bakes a directional assumption into the API.

A follow-up commit will deprecate `useDayNameForLastWeek` and wire up a `console.warn` pointing at the migration doc. This PR adds the replacement; the deprecation lands separately.