### PR TITLE
Deprecate useDayNameForLastWeek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added `useDayNameWithinWeek` option to `getAPDate`. Renders the weekday name for dates within a week of today in either direction, matching AP style.
 
+- Deprecated `useDayNameForLastWeek` in favor of `useDayNameWithinWeek`. Passing the old option emits a `console.warn`. The old option still works for now but will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.
+
 - **Breaking change**: `{includeYear: false}` now hides the year in every case.
 
   Previously, passing `false` was not a reliable way to hide the year: it behaved the same as `true` for the current year, and was silently ignored for past or future years. The option is now a symmetric counterpart to `{includeYear: true}`.

--- a/README.md
+++ b/README.md
@@ -106,22 +106,24 @@ Dateline(new Date(2012, 7, 28)).getAPDate({includeYear: false});
   Per AP style, weekday names stand in for the date within a week of the current date. The fallback kicks in at exactly seven days out in either direction — those dates render normally.
 
 ```js
-// Today is Wednesday, January 2, 2013
+// Today is Monday, June 22, 2009
 
-Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameWithinWeek: true});
+Dateline(new Date(2009, 5, 21)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Sunday'
+
+Dateline(new Date(2009, 5, 22)).getAPDate({useDayNameWithinWeek: true});
+// -> 'Monday'
+
+Dateline(new Date(2009, 5, 23)).getAPDate({useDayNameWithinWeek: true});
 // -> 'Tuesday'
 
-Dateline(new Date(2013, 0, 2)).getAPDate({useDayNameWithinWeek: true});
-// -> 'Wednesday'
-
-Dateline(new Date(2013, 0, 3)).getAPDate({useDayNameWithinWeek: true});
-// -> 'Thursday'
-
-Dateline(new Date(2013, 0, 9)).getAPDate({useDayNameWithinWeek: true});
-// -> 'Jan. 9'
+Dateline(new Date(2009, 5, 29)).getAPDate({useDayNameWithinWeek: true});
+// -> 'June 29'
 ```
 
-- `useDayNameForLastWeek`: Use the day of the week for dates in the last seven days:
+- `useDayNameForLastWeek` _(deprecated; use `useDayNameWithinWeek`)_: Use the day of the week for dates in the last seven days.
+
+  Passing `false` does not reliably opt out — for any date within the last seven days it still renders the weekday name. Only omitting the option (or passing `undefined` / `null`) produces the default. Deprecated in v4; will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.
 
 ```js
 // Today is June 22, 2009

--- a/dateline.js
+++ b/dateline.js
@@ -124,7 +124,21 @@ function useDayName(dateObj, options) {
   if (options.useDayNameWithinWeek != null) {
     return options.useDayNameWithinWeek && withinAWeek(dateObj);
   }
-  return options.useDayNameForLastWeek != null && withinSevenDays(dateObj);
+  if (options.useDayNameForLastWeek != null) {
+    warnDeprecatedOption("useDayNameForLastWeek", "useDayNameWithinWeek");
+    return withinSevenDays(dateObj);
+  }
+  return false;
+}
+
+function warnDeprecatedOption(oldName, newName) {
+  console.warn(
+    'dateline: "' +
+      oldName +
+      '" is deprecated. Use "' +
+      newName +
+      '" instead. See https://github.com/banterability/dateline/blob/main/docs/updatedOptions.md',
+  );
 }
 
 function withinSevenDays(dateObj) {

--- a/docs/updatedOptions.md
+++ b/docs/updatedOptions.md
@@ -1,0 +1,31 @@
+# Updated options
+
+Dateline occasionally replaces options with better-named or corrected alternatives. This doc lists the changes and how to migrate. Runtime deprecation warnings link here.
+
+## `useDayNameForLastWeek` → `useDayNameWithinWeek`
+
+Status: deprecated in v4, removed in v5.
+
+### Why
+
+Two problems with `useDayNameForLastWeek`:
+
+1. The name scopes to the past, but AP style uses weekday names in both directions — within seven days before or after the current date.
+2. `{useDayNameForLastWeek: false}` does **not** behave as a boolean "off." For any date within the last seven days it still renders the weekday name — the same result as `{useDayNameForLastWeek: true}`. Only omitting the option (or passing `undefined` / `null`) triggers the default.
+
+The bug is being left in place rather than fixed, to avoid silently changing behavior for anyone passing `false` deliberately. The replacement option is a clean break and covers the full AP-compliant window.
+
+### Migrate
+
+```js
+// before
+Dateline(date).getAPDate({useDayNameForLastWeek: true});
+
+// after
+Dateline(date).getAPDate({useDayNameWithinWeek: true});
+```
+
+`useDayNameWithinWeek` behaves as a normal boolean:
+
+- truthy → render the weekday name when the date is within a week of today, in either direction (today inclusive, the ±7-day boundaries excluded).
+- falsy or omitted → render the date normally.

--- a/test/date_test.js
+++ b/test/date_test.js
@@ -1,4 +1,13 @@
-import {describe, it, expect, beforeAll, afterAll, vi} from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  vi,
+} from "vitest";
 
 import Dateline from "../dateline.js";
 
@@ -145,6 +154,14 @@ describe("#getAPDate", function () {
       });
 
       describe('when "useDayNameForLastWeek" option is passed', function () {
+        beforeAll(function () {
+          vi.spyOn(console, "warn").mockImplementation(function () {});
+        });
+
+        afterAll(function () {
+          vi.restoreAllMocks();
+        });
+
         it("shows the day of the week for one day ago", function () {
           let actual = Dateline(new Date(2013, 0, 1)).getAPDate({
             useDayNameForLastWeek: true,
@@ -269,6 +286,43 @@ describe("#getAPDate", function () {
           });
           expect(actual).toBe("Jan. 9");
         });
+      });
+    });
+
+    describe('"useDayNameForLastWeek" deprecation warning', function () {
+      let warnSpy;
+
+      beforeEach(function () {
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(function () {});
+      });
+
+      afterEach(function () {
+        warnSpy.mockRestore();
+      });
+
+      it("warns when the deprecated option is passed", function () {
+        Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameForLastWeek: true});
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("useDayNameForLastWeek");
+        expect(warnSpy.mock.calls[0][0]).toContain("useDayNameWithinWeek");
+      });
+
+      it("warns on every call", function () {
+        let d = Dateline(new Date(2013, 0, 1));
+        d.getAPDate({useDayNameForLastWeek: true});
+        d.getAPDate({useDayNameForLastWeek: true});
+        d.getAPDate({useDayNameForLastWeek: true});
+        expect(warnSpy).toHaveBeenCalledTimes(3);
+      });
+
+      it("does not warn when the option is not passed", function () {
+        Dateline(new Date(2013, 0, 1)).getAPDate();
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it("does not warn when the replacement option is used", function () {
+        Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameWithinWeek: true});
+        expect(warnSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/readme_test.js
+++ b/test/readme_test.js
@@ -99,6 +99,61 @@ describe("README", function () {
             "Aug. 28, 2014",
           );
         });
+
+        it("includes the year for dates outside the current year", function () {
+          expect(Dateline(new Date(2012, 7, 28)).getAPDate()).toBe(
+            "Aug. 28, 2012",
+          );
+        });
+
+        it("omits the year for dates outside the current year if option is passed", function () {
+          expect(
+            Dateline(new Date(2012, 7, 28)).getAPDate({includeYear: false}),
+          ).toBe("Aug. 28");
+        });
+      });
+
+      describe('"useDayNameWithinWeek" option', function () {
+        beforeAll(function () {
+          vi.useFakeTimers();
+          vi.setSystemTime(new Date(2009, 5, 22));
+        });
+
+        afterAll(function () {
+          vi.useRealTimers();
+        });
+
+        it("uses the day name for yesterday", function () {
+          expect(
+            Dateline(new Date(2009, 5, 21)).getAPDate({
+              useDayNameWithinWeek: true,
+            }),
+          ).toBe("Sunday");
+        });
+
+        it("uses the day name for today", function () {
+          expect(
+            Dateline(new Date(2009, 5, 22)).getAPDate({
+              useDayNameWithinWeek: true,
+            }),
+          ).toBe("Monday");
+        });
+
+        it("uses the day name for tomorrow", function () {
+          expect(
+            Dateline(new Date(2009, 5, 23)).getAPDate({
+              useDayNameWithinWeek: true,
+            }),
+          ).toBe("Tuesday");
+        });
+
+        it("falls back to the formatted date outside the week window", function () {
+          expect(
+            Dateline(new Date(2009, 5, 29)).getAPDate({
+              useDayNameWithinWeek: true,
+            }),
+          ).toBe("June 29");
+        });
       });
 
       describe('"useDayNameForLastWeek" option', function () {
@@ -107,18 +162,20 @@ describe("README", function () {
         beforeAll(function () {
           vi.useFakeTimers();
           vi.setSystemTime(new Date(2009, 5, 22));
+          vi.spyOn(console, "warn").mockImplementation(function () {});
           myDate = new Date(2009, 5, 20);
         });
 
         afterAll(function () {
           vi.useRealTimers();
+          vi.restoreAllMocks();
         });
 
-        it("omits the year for dates in the current year", function () {
+        it("renders the formatted date by default", function () {
           expect(Dateline(myDate).getAPDate()).toBe("June 20");
         });
 
-        it("includes the year for dates in the current year if option is passed", function () {
+        it("uses the day name if option is passed", function () {
           expect(
             Dateline(myDate).getAPDate({useDayNameForLastWeek: true}),
           ).toBe("Saturday");


### PR DESCRIPTION
## tl;dr

Calling `getAPDate` with `useDayNameForLastWeek` now emits a `console.warn` pointing at its replacement, `useDayNameWithinWeek`. Behavior of the old option is unchanged; removal lands in v5.

## What changed?

- `getAPDate` emits `console.warn` on every call that passes `useDayNameForLastWeek` (any non-null value). The message names both options and links to the migration doc.
- New `docs/updatedOptions.md` explains the rename and how to migrate. Runtime warnings link there.

## Why?

`useDayNameForLastWeek` bakes a directional assumption into its name, but AP style uses weekday names in both directions within seven days of the current date. `useDayNameWithinWeek` (added in the previous commit) covers the full window. Deprecating now gives callers a release to migrate before the old option is removed in v5.

The `useDayNameForLastWeek != null` gate bug (where `false` behaves the same as `true`) is intentionally not being fixed. Patching a deprecated option risks surprising callers who might be passing `false` deliberately; pointing them at the replacement is the cleaner migration path.