### PR TITLE
Add `includeMinutesAtTopOfHour` option to `getAPTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Added `includeMinutesAtTopOfHour` option to `getAPTime`. Replaces `includeMinutes` with a name that reflects its actual scope — it only affects top-of-hour rendering — and respects `false` as a real "off" position.
+
 - Added `useDayNameWithinWeek` option to `getAPDate`. Renders the weekday name for dates within a week of today in either direction, matching AP style.
 
 - Deprecated `useDayNameForLastWeek` in favor of `useDayNameWithinWeek`. Passing the old option emits a `console.warn`. The old option still works for now but will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ moonWalk.getAPTime();
 
 Available options:
 
-- `includeMinutes`: Always include minutes, even at the top of the hour:
+- `includeMinutesAtTopOfHour`: Force `:00` at the top of the hour.
+
+  AP style omits the `:00` when referencing a time that lands on the hour, so the default renders `"2 p.m."` rather than `"2:00 p.m."`. Pass `true` to opt into the padded form. Special times (`midnight` and `noon`) are unaffected.
 
 ```js
 // The current time is 11:00 a.m....
@@ -65,6 +67,13 @@ Available options:
 Dateline().getAPTime();
 // -> '11 a.m.'
 
+Dateline().getAPTime({includeMinutesAtTopOfHour: true});
+// -> '11:00 a.m.'
+```
+
+- `includeMinutes`: Always include minutes, even at the top of the hour:
+
+```
 Dateline().getAPTime({includeMinutes: true});
 // -> '11:00 a.m.'
 ```

--- a/dateline.js
+++ b/dateline.js
@@ -104,6 +104,9 @@ function isTopOfHour(minutes) {
 }
 
 function showMinutes(minutes, options) {
+  if (options.includeMinutesAtTopOfHour != null) {
+    return isTopOfHour(minutes) && !options.includeMinutesAtTopOfHour;
+  }
   return isTopOfHour(minutes) && options.includeMinutes == null;
 }
 

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -49,5 +49,70 @@ describe("#getAPTime", function () {
         expect(actual).toBe("noon");
       });
     });
+
+    describe('"includeMinutesAtTopOfHour" option', function () {
+      describe("at the top of the hour", function () {
+        it("suppresses minutes when the option is missing", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 0)).getAPTime();
+          expect(actual).toBe("7 a.m.");
+        });
+
+        it("renders minutes when the option is true", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 0)).getAPTime({
+            includeMinutesAtTopOfHour: true,
+          });
+          expect(actual).toBe("7:00 a.m.");
+        });
+
+        it("suppresses minutes when the option is false", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 0)).getAPTime({
+            includeMinutesAtTopOfHour: false,
+          });
+          expect(actual).toBe("7 a.m.");
+        });
+      });
+
+      describe("mid-hour", function () {
+        it("renders minutes when the option is missing", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime();
+          expect(actual).toBe("7:01 a.m.");
+        });
+
+        it("renders minutes when the option is true", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime({
+            includeMinutesAtTopOfHour: true,
+          });
+          expect(actual).toBe("7:01 a.m.");
+        });
+
+        it("renders minutes when the option is false", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime({
+            includeMinutesAtTopOfHour: false,
+          });
+          expect(actual).toBe("7:01 a.m.");
+        });
+      });
+
+      describe("at noon", function () {
+        it('returns "noon" when the option is missing', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime();
+          expect(actual).toBe("noon");
+        });
+
+        it('returns "noon" when the option is true', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime({
+            includeMinutesAtTopOfHour: true,
+          });
+          expect(actual).toBe("noon");
+        });
+
+        it('returns "noon" when the option is false', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime({
+            includeMinutesAtTopOfHour: false,
+          });
+          expect(actual).toBe("noon");
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## tl;dr

Adds a new `includeMinutesAtTopOfHour` option to `getAPTime` that renders `:00` at the top of the hour. It replaces `includeMinutes` with a name that reflects its actual scope and respects `false` as a real "off" position.

## What changed?

- New `includeMinutesAtTopOfHour` option on `getAPTime`. Truthy renders `"11:00 a.m."`; falsy or omitted renders `"11 a.m."` (the AP default). Mid-hour times always render minutes regardless; `midnight` and `noon` literals are unaffected.
- Nine new tests covering `{missing, true, false}` × `{top-of-hour, mid-hour, noon}` in `test/time_test.js`.

## Why?

`includeMinutes` implied a global toggle but only ever affected top-of-hour rendering — mid-hour minutes render regardless of the option. The old name also suffered the same `== null` gate bug the other options had: `{includeMinutes: false}` forced `:00` on rather than honoring the AP default. Rather than fix those in place, the new option takes over with a name that signals its narrow scope and a real boolean semantic.

A follow-up commit will deprecate `includeMinutes` and wire up a `console.warn` pointing at the migration doc. This PR adds the replacement; the deprecation lands separately.