### PR TITLE
Deprecate `includeMinutes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added `includeMinutesAtTopOfHour` option to `getAPTime`. Replaces `includeMinutes` with a name that reflects its actual scope — it only affects top-of-hour rendering — and respects `false` as a real "off" position.
 
+- Deprecated `includeMinutes` in favor of `includeMinutesAtTopOfHour`. Passing the old option emits a `console.warn`. The old option still works for now but will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.
+
 - Added `useDayNameWithinWeek` option to `getAPDate`. Renders the weekday name for dates within a week of today in either direction, matching AP style.
 
 - Deprecated `useDayNameForLastWeek` in favor of `useDayNameWithinWeek`. Passing the old option emits a `console.warn`. The old option still works for now but will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ Dateline().getAPTime({includeMinutesAtTopOfHour: true});
 // -> '11:00 a.m.'
 ```
 
-- `includeMinutes`: Always include minutes, even at the top of the hour:
+- `includeMinutes` _(deprecated; use `includeMinutesAtTopOfHour`)_: Always include minutes, even at the top of the hour.
 
-```
+  Passing `false` does not reliably opt out — at the top of the hour it still renders `:00`. Only omitting the option (or passing `undefined` / `null`) produces the AP default. Deprecated in v4; will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.
+
+```js
+// The current time is 11:00 a.m....
+
 Dateline().getAPTime({includeMinutes: true});
 // -> '11:00 a.m.'
 ```

--- a/dateline.js
+++ b/dateline.js
@@ -107,7 +107,11 @@ function showMinutes(minutes, options) {
   if (options.includeMinutesAtTopOfHour != null) {
     return isTopOfHour(minutes) && !options.includeMinutesAtTopOfHour;
   }
-  return isTopOfHour(minutes) && options.includeMinutes == null;
+  if (options.includeMinutes != null) {
+    warnDeprecatedOption("includeMinutes", "includeMinutesAtTopOfHour");
+    return isTopOfHour(minutes) && options.includeMinutes == null;
+  }
+  return isTopOfHour(minutes);
 }
 
 // # Date Helpers

--- a/docs/updatedOptions.md
+++ b/docs/updatedOptions.md
@@ -2,6 +2,36 @@
 
 Dateline occasionally replaces options with better-named or corrected alternatives. This doc lists the changes and how to migrate. Runtime deprecation warnings link here.
 
+## `includeMinutes` → `includeMinutesAtTopOfHour`
+
+Status: deprecated in v4, removed in v5.
+
+### Why
+
+Two problems with `includeMinutes`:
+
+1. The name oversells its scope. It only affects rendering at the top of the hour. Mid-hour minutes always render regardless of the option.
+2. `{includeMinutes: false}` does **not** behave as a boolean "off." At the top of the hour it forces `:00` on — the same result as `{includeMinutes: true}`. Only omitting the option (or passing `undefined` / `null`) triggers the AP default.
+
+The bug is being left in place rather than fixed, to avoid silently changing behavior for anyone passing `false` deliberately. The replacement option is a clean break.
+
+### Migrate
+
+```js
+// before
+Dateline(date).getAPTime({includeMinutes: true});
+
+// after
+Dateline(date).getAPTime({includeMinutesAtTopOfHour: true});
+```
+
+`includeMinutesAtTopOfHour` behaves as a normal boolean:
+
+- truthy → render `:00` at the top of the hour (`"7:00 a.m."`).
+- falsy or omitted → suppress `:00` at the top of the hour (`"7 a.m."`, the AP default).
+
+Mid-hour renderings are unaffected either way. `midnight` and `noon` are also unaffected — those literals always win.
+
 ## `useDayNameForLastWeek` → `useDayNameWithinWeek`
 
 Status: deprecated in v4, removed in v5.

--- a/test/readme_test.js
+++ b/test/readme_test.js
@@ -50,10 +50,12 @@ describe("README", function () {
         beforeAll(function () {
           vi.useFakeTimers();
           vi.setSystemTime(new Date(2016, 3, 20, 11, 0));
+          vi.spyOn(console, "warn").mockImplementation(function () {});
         });
 
         afterAll(function () {
           vi.useRealTimers();
+          vi.restoreAllMocks();
         });
 
         it("omits minutes at the top of the hour", function () {

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -1,4 +1,13 @@
-import {describe, it, expect} from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  vi,
+} from "vitest";
 
 import Dateline from "../dateline.js";
 
@@ -27,6 +36,14 @@ describe("#getAPTime", function () {
 
   describe("special cases", function () {
     describe("top of the hour", function () {
+      beforeAll(function () {
+        vi.spyOn(console, "warn").mockImplementation(function () {});
+      });
+
+      afterAll(function () {
+        vi.restoreAllMocks();
+      });
+
       it("does not show minutes at the top of the hour by default", function () {
         let datelineObj = Dateline(new Date(2013, 7, 7, 14, 0));
         expect(datelineObj.getAPTime()).toBe("2 p.m.");
@@ -112,6 +129,45 @@ describe("#getAPTime", function () {
           });
           expect(actual).toBe("noon");
         });
+      });
+    });
+
+    describe('"includeMinutes" deprecation warning', function () {
+      let warnSpy;
+
+      beforeEach(function () {
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(function () {});
+      });
+
+      afterEach(function () {
+        warnSpy.mockRestore();
+      });
+
+      it("warns when the deprecated option is passed", function () {
+        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime({includeMinutes: true});
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy.mock.calls[0][0]).toContain("includeMinutes");
+        expect(warnSpy.mock.calls[0][0]).toContain("includeMinutesAtTopOfHour");
+      });
+
+      it("warns on every call", function () {
+        let d = Dateline(new Date(2013, 7, 7, 14, 0));
+        d.getAPTime({includeMinutes: true});
+        d.getAPTime({includeMinutes: true});
+        d.getAPTime({includeMinutes: true});
+        expect(warnSpy).toHaveBeenCalledTimes(3);
+      });
+
+      it("does not warn when the option is not passed", function () {
+        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime();
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it("does not warn when the replacement option is used", function () {
+        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime({
+          includeMinutesAtTopOfHour: true,
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## tl;dr

Calling `getAPTime` with `includeMinutes` now emits a `console.warn` pointing at its replacement, `includeMinutesAtTopOfHour`. Behavior of the old option is unchanged; removal lands in v5.

## What changed?

- `getAPTime` emits `console.warn` on every call that passes `includeMinutes` (any non-null value). The message names both options and links to the migration doc.
- `docs/updatedOptions.md` gains a section for the `includeMinutes → includeMinutesAtTopOfHour` rename. Runtime warnings link there.
- Existing tests that pass `includeMinutes` silence `console.warn` so test output stays pristine. Four new tests verify the warning fires on every call, references both option names, and doesn't fire for the replacement or when the option is omitted.

## Why?

`includeMinutes` oversold its scope — it only affects top-of-hour rendering, never mid-hour — and its `== null` gate treated `false` as `true`, so there was no way to opt out. `includeMinutesAtTopOfHour` (added in the previous commit) scopes itself accurately and behaves as a real boolean. Deprecating now gives callers a v4 release to migrate before the old option is removed in v5.

The `includeMinutes == null` gate bug is intentionally not being fixed. Patching a deprecated option risks surprising callers who might be passing `false` deliberately; pointing them at the replacement is the cleaner migration path.