### PR TITLE
Add `suppressAmPm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Added `suppressAmPm` option to `getAPTime`. Drops the trailing `a.m.` / `p.m.` suffix so callers can compose AP-style time ranges (e.g. `"7-8 p.m."`). `midnight` and `noon` literals are unaffected.
+
 - Added `includeMinutesAtTopOfHour` option to `getAPTime`. Replaces `includeMinutes` with a name that reflects its actual scope — it only affects top-of-hour rendering — and respects `false` as a real "off" position.
 
 - Deprecated `includeMinutes` in favor of `includeMinutesAtTopOfHour`. Passing the old option emits a `console.warn`. The old option still works for now but will be removed in v5. See [`docs/updatedOptions.md`](docs/updatedOptions.md) for the migration.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ Dateline().getAPTime({includeMinutes: true});
 // -> '11:00 a.m.'
 ```
 
+- `suppressAmPm`: Drop the trailing `a.m.` / `p.m.` suffix.
+
+  AP style omits the meridiem on the opening endpoint of a range — e.g. `"7-8 p.m."`, not `"7 p.m.-8 p.m."` — so callers composing ranges need a way to render a bare time. `midnight` and `noon` are unaffected.
+
+```js
+let start = Dateline(new Date(2013, 7, 7, 19, 0));
+let end = Dateline(new Date(2013, 7, 7, 20, 0));
+
+start.getAPTime({suppressAmPm: true}) + "-" + end.getAPTime();
+// -> '7-8 p.m.'
+
+Dateline(new Date(2013, 7, 7, 19, 1)).getAPTime({suppressAmPm: true});
+// -> '7:01'
+```
+
 **`#getAPDate(options)`** returns an AP-style date string:
 
 ```js

--- a/dateline.js
+++ b/dateline.js
@@ -45,18 +45,20 @@ let Dateline = function (dateObj) {
       return "noon";
     }
 
-    let timeOfDay = hours < 12 ? "a.m." : "p.m.";
+    let timeOfDay = options.suppressAmPm
+      ? ""
+      : " " + (hours < 12 ? "a.m." : "p.m.");
 
     let hour = formatHours(hours);
 
     // Don't show minutes at the top of the hour by default
     if (showMinutes(minutes, options)) {
-      return hour + " " + timeOfDay;
+      return hour + timeOfDay;
     }
 
     let minute = formatMinutes(minutes);
 
-    return hour + ":" + minute + " " + timeOfDay;
+    return hour + ":" + minute + timeOfDay;
   };
 
   dateObj.getAPDate = function (options) {

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -132,6 +132,50 @@ describe("#getAPTime", function () {
       });
     });
 
+    describe('"suppressAmPm" option', function () {
+      describe("mid-hour", function () {
+        it("renders the meridiem when the option is missing", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime();
+          expect(actual).toBe("7:01 a.m.");
+        });
+
+        it("drops the meridiem when the option is true", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime({
+            suppressAmPm: true,
+          });
+          expect(actual).toBe("7:01");
+        });
+
+        it("renders the meridiem when the option is false", function () {
+          let actual = Dateline(new Date(2013, 7, 7, 7, 1)).getAPTime({
+            suppressAmPm: false,
+          });
+          expect(actual).toBe("7:01 a.m.");
+        });
+      });
+
+      describe("at noon", function () {
+        it('returns "noon" when the option is missing', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime();
+          expect(actual).toBe("noon");
+        });
+
+        it('returns "noon" when the option is true', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime({
+            suppressAmPm: true,
+          });
+          expect(actual).toBe("noon");
+        });
+
+        it('returns "noon" when the option is false', function () {
+          let actual = Dateline(new Date(2013, 0, 1, 12, 0)).getAPTime({
+            suppressAmPm: false,
+          });
+          expect(actual).toBe("noon");
+        });
+      });
+    });
+
     describe('"includeMinutes" deprecation warning', function () {
       let warnSpy;
 


### PR DESCRIPTION
## tl;dr

Adds a new `suppressAmPm` option to `getAPTime` that drops the trailing `a.m.` / `p.m.` suffix. Gives callers the primitive they need to compose AP-style time ranges like `"7-8 p.m."`.

## What changed?

- New `suppressAmPm` option on `getAPTime`. Truthy renders `"7:01"`; falsy or omitted renders `"7:01 a.m."`. `midnight` and `noon` literals are unaffected — they return before options are consulted.
- Six new tests covering `{missing, true, false}` × `{mid-hour, noon}` in `test/time_test.js`.

## Why?

AP style drops the trailing meridiem on the opening endpoint of a range: `"7-8 p.m."`, not `"7 p.m.-8 p.m."`. Dateline doesn't format ranges itself, but callers composing them need a way to get a digit-only response.