### PR TITLE
Remove deprecated `includeMinutes` and `useDayNameForLastWeek`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Removed
+
+- **Removed**: `includeMinutes` option on `getAPTime`. Deprecated in v4; replaced by `includeMinutesAtTopOfHour`. See [`docs/options-v4-v5.md`](docs/options-v4-v5.md) for the migration.
+
+- **Removed**: `useDayNameForLastWeek` option on `getAPDate`. Deprecated in v4; replaced by `useDayNameWithinWeek`. See [`docs/options-v4-v5.md`](docs/options-v4-v5.md) for the migration.
+
 ## 4.0.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -71,17 +71,6 @@ Dateline().getAPTime({includeMinutesAtTopOfHour: true});
 // -> '11:00 a.m.'
 ```
 
-- `includeMinutes` _(deprecated; use `includeMinutesAtTopOfHour`)_: Always include minutes, even at the top of the hour.
-
-  Passing `false` does not reliably opt out — at the top of the hour it still renders `:00`. Only omitting the option (or passing `undefined` / `null`) produces the AP default. Deprecated in v4; will be removed in v5. See [`docs/options-v4-v5.md`](docs/options-v4-v5.md) for the migration.
-
-```js
-// The current time is 11:00 a.m....
-
-Dateline().getAPTime({includeMinutes: true});
-// -> '11:00 a.m.'
-```
-
 - `suppressAmPm`: Drop the trailing `a.m.` / `p.m.` suffix.
 
   AP style omits the meridiem on the opening endpoint of a range — e.g. `"7-8 p.m."`, not `"7 p.m.-8 p.m."` — so callers composing ranges need a way to render a bare time. `midnight` and `noon` are unaffected.
@@ -147,20 +136,4 @@ Dateline(new Date(2009, 5, 23)).getAPDate({useDayNameWithinWeek: true});
 
 Dateline(new Date(2009, 5, 29)).getAPDate({useDayNameWithinWeek: true});
 // -> 'June 29'
-```
-
-- `useDayNameForLastWeek` _(deprecated; use `useDayNameWithinWeek`)_: Use the day of the week for dates in the last seven days.
-
-  Passing `false` does not reliably opt out — for any date within the last seven days it still renders the weekday name. Only omitting the option (or passing `undefined` / `null`) produces the default. Deprecated in v4; will be removed in v5. See [`docs/options-v4-v5.md`](docs/options-v4-v5.md) for the migration.
-
-```js
-// Today is June 22, 2009
-
-var myDate = new Date(2009, 5, 20);
-
-Dateline(myDate).getAPDate();
-// -> 'June 20'
-
-Dateline(myDate).getAPDate({useDayNameForLastWeek: true});
-// -> 'Saturday'
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Dateline(new Date(2013, 7, 7, 19, 1)).getAPTime({suppressAmPm: true});
 **`#getAPDate(options)`** returns an AP-style date string:
 
 ```js
+// Today is April 29, 2014
+
 newYears.getAPDate();
 // -> 'Jan. 1'
 
@@ -118,9 +120,9 @@ Dateline(new Date(2012, 7, 28)).getAPDate({includeYear: false});
 // -> 'Aug. 28'
 ```
 
-- `useDayNameWithinWeek`: Use the day of the week for dates within seven days of today, in either direction.
+- `useDayNameWithinWeek`: When `true`, render dates within a week of today as weekday names.
 
-  Per AP style, weekday names stand in for the date within a week of the current date. The fallback kicks in at exactly seven days out in either direction — those dates render normally.
+  Dates less than seven days away in either direction render as `'Monday'`, `'Tuesday'`, etc. Dates further out are unaffected — they render as the normal month-and-day. Per AP style, weekday names stand in for the date within a week of the current date.
 
 ```js
 // Today is Monday, June 22, 2009

--- a/dateline.d.ts
+++ b/dateline.d.ts
@@ -1,15 +1,11 @@
 export interface APTimeOptions {
   includeMinutesAtTopOfHour?: boolean;
   suppressAmPm?: boolean;
-  /** @deprecated Use `includeMinutesAtTopOfHour`. Will be removed in v5. */
-  includeMinutes?: boolean;
 }
 
 export interface APDateOptions {
   includeYear?: boolean;
   useDayNameWithinWeek?: boolean;
-  /** @deprecated Use `useDayNameWithinWeek`. Will be removed in v5. */
-  useDayNameForLastWeek?: boolean;
 }
 
 export interface DatelineDate extends Date {

--- a/dateline.js
+++ b/dateline.js
@@ -103,15 +103,8 @@ function isTopOfHour(minutes) {
 }
 
 function showMinutes(minutes, options) {
-  if (options.includeMinutesAtTopOfHour != null) {
-    if (!isTopOfHour(minutes)) return true;
-    return !!options.includeMinutesAtTopOfHour;
-  }
-  if (options.includeMinutes != null) {
-    warnDeprecatedOption("includeMinutes", "includeMinutesAtTopOfHour");
-    return true;
-  }
-  return !isTopOfHour(minutes);
+  if (!isTopOfHour(minutes)) return true;
+  return !!options.includeMinutesAtTopOfHour;
 }
 
 // # Date Helpers
@@ -128,29 +121,7 @@ function getDayOfWeek(dateObj) {
 }
 
 function useDayName(dateObj, options) {
-  if (options.useDayNameWithinWeek != null) {
-    return options.useDayNameWithinWeek && withinAWeek(dateObj);
-  }
-  if (options.useDayNameForLastWeek != null) {
-    warnDeprecatedOption("useDayNameForLastWeek", "useDayNameWithinWeek");
-    return withinSevenDays(dateObj);
-  }
-  return false;
-}
-
-function warnDeprecatedOption(oldName, newName) {
-  console.warn(
-    'dateline: "' +
-      oldName +
-      '" is deprecated. Use "' +
-      newName +
-      '" instead. See https://github.com/banterability/dateline/blob/main/docs/options-v4-v5.md',
-  );
-}
-
-function withinSevenDays(dateObj) {
-  let diffInDays = (dateObj - new Date()) / ONE_DAY_IN_MS;
-  return -7 < diffInDays && diffInDays < 0;
+  return !!options.useDayNameWithinWeek && withinAWeek(dateObj);
 }
 
 function withinAWeek(dateObj) {

--- a/test/date_test.js
+++ b/test/date_test.js
@@ -1,13 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterAll,
-  afterEach,
-  vi,
-} from "vitest";
+import {describe, it, expect, beforeAll, afterAll, vi} from "vitest";
 
 import Dateline from "../dateline.js";
 
@@ -152,65 +143,6 @@ describe("#getAPDate", function () {
           expect(actual).toBe("Dec. 26, 2012");
         });
       });
-
-      describe('when "useDayNameForLastWeek" option is passed', function () {
-        beforeAll(function () {
-          vi.spyOn(console, "warn").mockImplementation(function () {});
-        });
-
-        afterAll(function () {
-          vi.restoreAllMocks();
-        });
-
-        it("shows the day of the week for one day ago", function () {
-          let actual = Dateline(new Date(2013, 0, 1)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Tuesday");
-        });
-
-        it("shows the day of the week for two days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 31)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Monday");
-        });
-
-        it("shows the day of the week for three days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 30)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Sunday");
-        });
-
-        it("shows the day of the week for four days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 29)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Saturday");
-        });
-
-        it("shows the day of the week for five days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 28)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Friday");
-        });
-
-        it("shows the day of the week for six days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 27)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Thursday");
-        });
-
-        it("shows the date seven days ago", function () {
-          let actual = Dateline(new Date(2012, 11, 26)).getAPDate({
-            useDayNameForLastWeek: true,
-          });
-          expect(actual).toBe("Dec. 26, 2012");
-        });
-      });
     });
 
     describe("dates within a week in either direction", function () {
@@ -286,43 +218,6 @@ describe("#getAPDate", function () {
           });
           expect(actual).toBe("Jan. 9");
         });
-      });
-    });
-
-    describe('"useDayNameForLastWeek" deprecation warning', function () {
-      let warnSpy;
-
-      beforeEach(function () {
-        warnSpy = vi.spyOn(console, "warn").mockImplementation(function () {});
-      });
-
-      afterEach(function () {
-        warnSpy.mockRestore();
-      });
-
-      it("warns when the deprecated option is passed", function () {
-        Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameForLastWeek: true});
-        expect(warnSpy).toHaveBeenCalledOnce();
-        expect(warnSpy.mock.calls[0][0]).toContain("useDayNameForLastWeek");
-        expect(warnSpy.mock.calls[0][0]).toContain("useDayNameWithinWeek");
-      });
-
-      it("warns on every call", function () {
-        let d = Dateline(new Date(2013, 0, 1));
-        d.getAPDate({useDayNameForLastWeek: true});
-        d.getAPDate({useDayNameForLastWeek: true});
-        d.getAPDate({useDayNameForLastWeek: true});
-        expect(warnSpy).toHaveBeenCalledTimes(3);
-      });
-
-      it("does not warn when the option is not passed", function () {
-        Dateline(new Date(2013, 0, 1)).getAPDate();
-        expect(warnSpy).not.toHaveBeenCalled();
-      });
-
-      it("does not warn when the replacement option is used", function () {
-        Dateline(new Date(2013, 0, 1)).getAPDate({useDayNameWithinWeek: true});
-        expect(warnSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/test/readme_test.js
+++ b/test/readme_test.js
@@ -84,25 +84,6 @@ describe("README", function () {
           ).toBe("7:01");
         });
       });
-
-      describe('"includeMinutes" option', function () {
-        beforeAll(function () {
-          vi.useFakeTimers();
-          vi.setSystemTime(new Date(2016, 3, 20, 11, 0));
-          vi.spyOn(console, "warn").mockImplementation(function () {});
-        });
-
-        afterAll(function () {
-          vi.useRealTimers();
-          vi.restoreAllMocks();
-        });
-
-        it("includes minutes at the top of the hour if option is passed", function () {
-          expect(Dateline().getAPTime({includeMinutes: true})).toBe(
-            "11:00 a.m.",
-          );
-        });
-      });
     });
 
     describe("#getAPDate", function () {
@@ -190,32 +171,6 @@ describe("README", function () {
               useDayNameWithinWeek: true,
             }),
           ).toBe("June 29");
-        });
-      });
-
-      describe('"useDayNameForLastWeek" option', function () {
-        let myDate;
-
-        beforeAll(function () {
-          vi.useFakeTimers();
-          vi.setSystemTime(new Date(2009, 5, 22));
-          vi.spyOn(console, "warn").mockImplementation(function () {});
-          myDate = new Date(2009, 5, 20);
-        });
-
-        afterAll(function () {
-          vi.useRealTimers();
-          vi.restoreAllMocks();
-        });
-
-        it("renders the formatted date by default", function () {
-          expect(Dateline(myDate).getAPDate()).toBe("June 20");
-        });
-
-        it("uses the day name if option is passed", function () {
-          expect(
-            Dateline(myDate).getAPDate({useDayNameForLastWeek: true}),
-          ).toBe("Saturday");
         });
       });
     });

--- a/test/time_test.js
+++ b/test/time_test.js
@@ -1,13 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  beforeEach,
-  afterAll,
-  afterEach,
-  vi,
-} from "vitest";
+import {describe, it, expect} from "vitest";
 
 import Dateline from "../dateline.js";
 
@@ -36,22 +27,9 @@ describe("#getAPTime", function () {
 
   describe("special cases", function () {
     describe("top of the hour", function () {
-      beforeAll(function () {
-        vi.spyOn(console, "warn").mockImplementation(function () {});
-      });
-
-      afterAll(function () {
-        vi.restoreAllMocks();
-      });
-
       it("does not show minutes at the top of the hour by default", function () {
         let datelineObj = Dateline(new Date(2013, 7, 7, 14, 0));
         expect(datelineObj.getAPTime()).toBe("2 p.m.");
-      });
-
-      it("shows minutes at the top of the hour when includeMinutes is passed", function () {
-        let datelineObj = Dateline(new Date(2013, 7, 7, 14, 0));
-        expect(datelineObj.getAPTime({includeMinutes: true})).toBe("2:00 p.m.");
       });
     });
 
@@ -194,45 +172,6 @@ describe("#getAPTime", function () {
           });
           expect(actual).toBe("noon");
         });
-      });
-    });
-
-    describe('"includeMinutes" deprecation warning', function () {
-      let warnSpy;
-
-      beforeEach(function () {
-        warnSpy = vi.spyOn(console, "warn").mockImplementation(function () {});
-      });
-
-      afterEach(function () {
-        warnSpy.mockRestore();
-      });
-
-      it("warns when the deprecated option is passed", function () {
-        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime({includeMinutes: true});
-        expect(warnSpy).toHaveBeenCalledOnce();
-        expect(warnSpy.mock.calls[0][0]).toContain("includeMinutes");
-        expect(warnSpy.mock.calls[0][0]).toContain("includeMinutesAtTopOfHour");
-      });
-
-      it("warns on every call", function () {
-        let d = Dateline(new Date(2013, 7, 7, 14, 0));
-        d.getAPTime({includeMinutes: true});
-        d.getAPTime({includeMinutes: true});
-        d.getAPTime({includeMinutes: true});
-        expect(warnSpy).toHaveBeenCalledTimes(3);
-      });
-
-      it("does not warn when the option is not passed", function () {
-        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime();
-        expect(warnSpy).not.toHaveBeenCalled();
-      });
-
-      it("does not warn when the replacement option is used", function () {
-        Dateline(new Date(2013, 7, 7, 14, 0)).getAPTime({
-          includeMinutesAtTopOfHour: true,
-        });
-        expect(warnSpy).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## tl;dr

Removes `includeMinutes` and `useDayNameForLastWeek`, both deprecated in v4.

## What changed?

- **Removed** `includeMinutes` option on `getAPTime`. Replaced by `includeMinutesAtTopOfHour` in v4.
- **Removed** `useDayNameForLastWeek` option on `getAPDate`. Replaced by `useDayNameWithinWeek` in v4.
- Types: removed the two `@deprecated` entries from `dateline.d.ts`.
- Tests: dropped 19 tests that exercised the old options and their deprecation warnings; cleaned up unused imports and `console.warn` mocking that was there to silence the warnings.
- README: removed both deprecated-option sections.

## Why?

v4 introduced replacements for both options and wired up runtime warnings pointing at the migration doc.

Callers who haven't migrated will get silent default behavior rather than the old buggy semantics — acceptable given the v4 warning window. `docs/options-v4-v5.md` is left in place as the reference for anyone upgrading from v3 or earlier.