### PR TITLE
Fix `useDayNameWithinWeek` window to use calendar days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- `useDayNameWithinWeek` now measures its window against calendar days rather than counting out milliseconds. Previously the same target date could render as a weekday or a formatted date depending on the time of day when `getAPDate` was called. Technically a breaking change, but the old behavior was never intentional, so let's call it a bug fix.
+
 ## 5.0.0
 
 ### Breaking changes

--- a/dateline.js
+++ b/dateline.js
@@ -125,6 +125,11 @@ function useDayName(dateObj, options) {
 }
 
 function withinAWeek(dateObj) {
-  let diffInDays = (dateObj - new Date()) / ONE_DAY_IN_MS;
+  let diffInDays =
+    (startOfDay(dateObj) - startOfDay(new Date())) / ONE_DAY_IN_MS;
   return -7 < diffInDays && diffInDays < 7;
+}
+
+function startOfDay(dateObj) {
+  return new Date(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate());
 }

--- a/test/date_test.js
+++ b/test/date_test.js
@@ -219,6 +219,26 @@ describe("#getAPDate", function () {
           expect(actual).toBe("Jan. 9");
         });
       });
+
+      describe("window is measured in calendar days, not wall-clock hours", function () {
+        it("excludes a target seven calendar days ahead when called late in the day", function () {
+          vi.setSystemTime(new Date(2013, 0, 2, 23, 30));
+          let target = new Date(2013, 0, 9, 12, 0);
+          let actual = Dateline(target).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Jan. 9");
+        });
+
+        it("excludes a target seven calendar days ago when called early in the day", function () {
+          vi.setSystemTime(new Date(2013, 0, 2, 5, 0));
+          let target = new Date(2012, 11, 26, 12, 0);
+          let actual = Dateline(target).getAPDate({
+            useDayNameWithinWeek: true,
+          });
+          expect(actual).toBe("Dec. 26, 2012");
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## tl;dr

`useDayNameWithinWeek` now decides its window against calendar days instead of counting out milliseconds.

## What changed?

- `withinAWeek` diffs `startOfDay(dateObj)` against `startOfDay(new Date())` before comparing to ±7. A new `startOfDay` helper drops the time component to local midnight.
- New test block `window is measured in calendar days, not wall-clock hours` pins the behavior with a target seven calendar days out called late at night, and a target seven calendar days back called early in the morning. Both previously rendered as weekday names; now they fall back to the formatted date.

## Why?

The old implementation measured a rolling 168-hour span. That meant a target date set to noon seven calendar days out could render as `"Wednesday"` at one point in the day and `"Jan. 9"` at another. AP style reads as calendar-day semantics ("within seven days before or after the current date"), and that's almost certainly what callers setting the option expect. Time-of-day sensitivity was a leak of the implementation, not a feature.

Strictly speaking this is a breaking change — targets near the boundary will render differently — but the previous behavior was never intentional, so let's call it a bug fix.